### PR TITLE
enhance: 태그 API와 Notion 연동 시스템 개선

### DIFF
--- a/src/app/api/tags/debug/route.ts
+++ b/src/app/api/tags/debug/route.ts
@@ -40,7 +40,13 @@ export async function GET(request: NextRequest) {
     console.log('🔍 Starting debug analysis...')
 
     // 3. URL 파라미터에서 옵션 파싱
-    const pageSize = parseInt(request.nextUrl.searchParams.get('page_size') || '5', 10)
+    const pageSizeParam = request.nextUrl.searchParams.get('page_size')
+    const parsedPageSize = parseInt(pageSizeParam || '5', 10)
+    // NaN 체크 후 안전한 기본값 사용, 1-100 범위로 제한
+    const pageSize = isNaN(parsedPageSize)
+      ? 5
+      : Math.max(1, Math.min(parsedPageSize, 100))
+
     const statusFilter = request.nextUrl.searchParams.get('status') || 'Published'
 
     // 첫 번째 페이지만 가져와서 구조 분석
@@ -52,7 +58,7 @@ export async function GET(request: NextRequest) {
           equals: statusFilter,
         },
       },
-      page_size: Math.min(pageSize, 100), // 최대 100개로 제한
+      page_size: pageSize, // 항상 1-100 사이의 정수
     })
 
     const debugInfo = {

--- a/src/app/api/tags/debug/route.ts
+++ b/src/app/api/tags/debug/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { Client } from '@notionhq/client'
 
 const notion = new Client({
@@ -14,7 +14,7 @@ const DEBUG_SECRET = process.env.DEBUG_SECRET || process.env.REVALIDATE_SECRET /
  * 디버깅용 엔드포인트 - 실제 Notion 데이터 구조 확인
  * Production에서는 비활성화되며, 개발 환경에서도 Bearer 토큰 인증 필요
  */
-export async function GET(request: NextRequest) {
+export async function GET(request: Request) {
   try {
     // 1. Production 환경에서는 접근 차단
     if (process.env.NODE_ENV === 'production') {
@@ -24,9 +24,13 @@ export async function GET(request: NextRequest) {
       )
     }
 
+    // URL 객체 생성하여 안전하게 파라미터 추출
+    const url = new URL(request.url)
+    const searchParams = url.searchParams
+
     // 2. Bearer 토큰 검증
     const authHeader = request.headers.get('Authorization')
-    const token = request.nextUrl.searchParams.get('token') // 쿼리 파라미터로도 받을 수 있도록
+    const token = searchParams.get('token') // 쿼리 파라미터로도 받을 수 있도록
 
     const providedToken = authHeader?.replace('Bearer ', '') || token
 
@@ -40,14 +44,14 @@ export async function GET(request: NextRequest) {
     console.log('🔍 Starting debug analysis...')
 
     // 3. URL 파라미터에서 옵션 파싱
-    const pageSizeParam = request.nextUrl.searchParams.get('page_size')
+    const pageSizeParam = searchParams.get('page_size')
     const parsedPageSize = parseInt(pageSizeParam || '5', 10)
     // NaN 체크 후 안전한 기본값 사용, 1-100 범위로 제한
     const pageSize = isNaN(parsedPageSize)
       ? 5
       : Math.max(1, Math.min(parsedPageSize, 100))
 
-    const statusFilter = request.nextUrl.searchParams.get('status') || 'Published'
+    const statusFilter = searchParams.get('status') || 'Published'
 
     // 첫 번째 페이지만 가져와서 구조 분석
     const response = await notion.databases.query({

--- a/src/app/api/tags/debug/route.ts
+++ b/src/app/api/tags/debug/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server'
+import { Client } from '@notionhq/client'
+
+const notion = new Client({
+  auth: process.env.NOTION_TOKEN,
+})
+
+const DATABASE_ID = process.env.NOTION_DATABASE_ID!
+
+/**
+ * GET /api/tags/debug
+ * 
+ * 디버깅용 엔드포인트 - 실제 Notion 데이터 구조 확인
+ */
+export async function GET() {
+  try {
+    console.log('🔍 Starting debug analysis...')
+    
+    // 첫 번째 페이지만 가져와서 구조 분석
+    const response = await notion.databases.query({
+      database_id: DATABASE_ID,
+      filter: {
+        property: 'status',
+        select: {
+          equals: 'Published',
+        },
+      },
+      page_size: 5, // 처음 5개만
+    })
+
+    const debugInfo = {
+      totalResults: response.results.length,
+      hasMore: response.has_more,
+      samplePosts: response.results.map((page: any) => {
+        const properties = page.properties
+        return {
+          id: page.id,
+          title: properties.title?.title?.[0]?.plain_text || 'No title',
+          status: properties.status?.select?.name || 'No status',
+          tags: {
+            raw: properties.tags,
+            processed: properties.tags?.multi_select?.map((tag: any) => ({
+              id: tag.id,
+              name: tag.name,
+              color: tag.color,
+              isEmpty: !tag.name || tag.name.trim().length === 0
+            })) || []
+          }
+        }
+      }),
+      // 데이터베이스 스키마 정보
+      databaseSchema: null
+    }
+
+    // 데이터베이스 스키마도 가져오기
+    try {
+      const dbInfo = await notion.databases.retrieve({ database_id: DATABASE_ID })
+      debugInfo.databaseSchema = {
+        title: dbInfo.title,
+        properties: Object.keys(dbInfo.properties).reduce((acc: any, key) => {
+          const prop = (dbInfo.properties as any)[key]
+          acc[key] = {
+            type: prop.type,
+            name: prop.name || key
+          }
+          return acc
+        }, {})
+      }
+    } catch (schemaError) {
+      console.error('Error fetching database schema:', schemaError)
+    }
+
+    console.log('🔍 Debug info collected:', JSON.stringify(debugInfo, null, 2))
+
+    return NextResponse.json(debugInfo)
+  } catch (error) {
+    console.error('❌ Debug API error:', error)
+    
+    return NextResponse.json(
+      { 
+        error: 'Failed to fetch debug info',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/tags/debug/route.ts
+++ b/src/app/api/tags/debug/route.ts
@@ -17,6 +17,33 @@ const notion = new Client({
 const DATABASE_ID = process.env.NOTION_DATABASE_ID!
 const DEBUG_SECRET = process.env.DEBUG_SECRET || process.env.REVALIDATE_SECRET // 디버그용 시크릿 토큰
 
+// Debug response type definition
+type DebugInfo = {
+  totalResults: number
+  hasMore: boolean
+  samplePosts: Array<{
+    id: string
+    title: string
+    status: string
+    tags: {
+      raw: unknown
+      processed: Array<{
+        id: string
+        name: string
+        color: string
+        isEmpty: boolean
+      }>
+    }
+  }>
+  databaseSchema: {
+    title: string
+    properties: Record<string, {
+      type: string
+      name: string
+    }>
+  } | null
+}
+
 /**
  * GET /api/tags/debug
  *
@@ -115,7 +142,7 @@ export async function GET(request: Request) {
 
     const response: QueryDatabaseResponse = await notion.databases.query(queryOptions)
 
-    const debugInfo = {
+    const debugInfo: DebugInfo = {
       totalResults: response.results.length,
       hasMore: response.has_more,
       samplePosts: response.results.map((page) => {


### PR DESCRIPTION
- API route에 향상된 타입 안전성과 에러 처리 추가
- 디버그 모드 지원으로 개발 편의성 증대
- Notion 라이브러리에 더 나은 태그 관리 및 캐싱 구현
- 태그 중복 제거 및 정규화 로직 강화
- 캐시 관리 함수들 추가 (clearTagCache, getTagCacheInfo)
- 실제 포스트 수 계산을 위한 getTotalPublishedPostsCount 함수 추가
- 디버그 디렉토리 추가로 테스트 지원

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 비프로덕션 전용 디버그 엔드포인트 추가 — 환경 요약, 데이터베이스 스키마 개요, 샘플 게시물 및 페이징 정보 제공(인증 필요).
  * 응답에 전체 공개 게시물 수 포함 — 태그 통계와 표시 정확성 향상.
  * 태그 캐시 상태 조회 및 캐시 초기화 기능 추가 — 운영·디버깅 편의성 향상.

* 버그 수정
  * 태그 이름 정규화·중복 처리 및 에러 회복력 개선으로 중복·불일치 표시 감소 및 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->